### PR TITLE
Make sure we don't pop immediate in onBackStackChanged. Fixes #4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,12 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.3"
+
     defaultConfig {
         applicationId "org.dmfs.android.microfragments.demo"
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -25,9 +26,9 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     compile project(':microfragments')
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:design:23.4.0'
-    compile 'com.android.support:support-v4:23.4.0'
+    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:design:25.3.1'
+    compile 'com.android.support:support-v4:25.3.1'
     compile 'com.github.dmfs.PigeonPost:localbroadcast-pigeon:0.3'
     testCompile 'junit:junit:4.12'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Mon Jun 05 16:00:03 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/microfragments/build.gradle
+++ b/microfragments/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
 
@@ -26,7 +26,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:23.4.0'
+    compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.github.dmfs.PigeonPost:pigeon-post:0.3'
     compile 'com.github.dmfs.PigeonPost:localbroadcast-pigeon:0.3'
     testCompile 'junit:junit:4.12'

--- a/microfragments/src/main/java/org/dmfs/android/microfragments/HostFragment.java
+++ b/microfragments/src/main/java/org/dmfs/android/microfragments/HostFragment.java
@@ -154,15 +154,6 @@ public final class HostFragment extends Fragment implements FragmentManager.OnBa
     @Override
     public void onBackStackChanged()
     {
-        if (mFragmentManager.getBackStackEntryCount() < mBackStackDepth)
-        {
-            // the user went back, make sure we skip all skipable steps.
-            if (mFragmentManager.getBackStackEntryCount() > 0
-                    && "skip".equals(mFragmentManager.getBackStackEntryAt(mFragmentManager.getBackStackEntryCount() - 1).getName()))
-            {
-                mFragmentManager.popBackStackImmediate("skip", FragmentManager.POP_BACK_STACK_INCLUSIVE);
-            }
-        }
         mBackStackDepth = mFragmentManager.getBackStackEntryCount();
 
         postUpdate(new FragmentEnvironment<>(currentFragment()).microFragment());

--- a/microfragments/src/main/java/org/dmfs/android/microfragments/transitions/BackTransition.java
+++ b/microfragments/src/main/java/org/dmfs/android/microfragments/transitions/BackTransition.java
@@ -110,7 +110,15 @@ public final class BackTransition implements FragmentTransition
     @Override
     public void prepare(@NonNull Context context, @NonNull FragmentManager fragmentManager, @NonNull MicroFragmentHost host, @NonNull MicroFragment<?> previousStep)
     {
-        mResponseCage.pigeon(fragmentManager.popBackStackImmediate()).send(context);
+        boolean result = fragmentManager.popBackStackImmediate();
+        // make sure we also skip all skipable steps.
+        if (result && fragmentManager.getBackStackEntryCount() > 0
+                && "skip".equals(fragmentManager.getBackStackEntryAt(fragmentManager.getBackStackEntryCount() - 1).getName()))
+        {
+            fragmentManager.popBackStackImmediate("skip", FragmentManager.POP_BACK_STACK_INCLUSIVE);
+        }
+
+        mResponseCage.pigeon(result).send(context);
     }
 
 

--- a/microfragments/src/main/java/org/dmfs/android/microfragments/transitions/BackWithResultTransition.java
+++ b/microfragments/src/main/java/org/dmfs/android/microfragments/transitions/BackWithResultTransition.java
@@ -83,6 +83,12 @@ public final class BackWithResultTransition<T extends Parcelable> implements Fra
     public void prepare(@NonNull Context context, @NonNull FragmentManager fragmentManager, @NonNull MicroFragmentHost host, @NonNull MicroFragment<?> previousStep)
     {
         fragmentManager.popBackStackImmediate();
+        // make sure we also skip all skipable steps.
+        if (fragmentManager.getBackStackEntryCount() > 0
+                && "skip".equals(fragmentManager.getBackStackEntryAt(fragmentManager.getBackStackEntryCount() - 1).getName()))
+        {
+            fragmentManager.popBackStackImmediate("skip", FragmentManager.POP_BACK_STACK_INCLUSIVE);
+        }
     }
 
 


### PR DESCRIPTION
Skip skipable steps right in the Transaction not in `onBackStackChanged` to make sure it doesn't crash with recent versions of the support library.